### PR TITLE
Update to look for mods in new BeamNG mod folder

### DIFF
--- a/sim_racing_tools/assetto_corsa/docs/swap_automation_engine.md
+++ b/sim_racing_tools/assetto_corsa/docs/swap_automation_engine.md
@@ -19,7 +19,8 @@ ac-tools swap-automation-engine <name-of-ac-car-folder> <name-of-beamng-mod-fold
 The tool assumes:
 - the Assetto Corsa car you are transferring the engine data to resides within the standard Assetto Corsa installation directory 
 - the AC car has its data.acd file unpacked into a data folder
-- the BeamNG mod that you wish to export the engine from resides within the standard BeamNG mod folder - if you don't have BeamNG installed then you will need to create this folder `Documents/BeamNG.drive/mods`.
+- the BeamNG mod that you wish to export the engine from resides within the standard BeamNG mod folder or in `Documents/BeamNG.drive/mods` - if you don't have BeamNG installed then you will need to create this folder.
+  > Note that `Documents` refers to the library set up by Windows. In an explorer window this will be in your Quick Access bar
 ### Example
 ```commandline
 ac-tools swap-automation-engine tatuusfa1 myBeamNGMod

--- a/sim_racing_tools/automation/fabricator/assetto_corsa/engine.py
+++ b/sim_racing_tools/automation/fabricator/assetto_corsa/engine.py
@@ -276,12 +276,21 @@ def create_turbo_sections_v1(engine, engine_data):
 
 
 def get_mod_data_dir(beamng_mod_folder_name):
-    car_export_path = os.path.join(installation.get_beamng_export_path(),
-                                   beamng_mod_folder_name)
-    if not os.path.isdir(car_export_path):
-        utils.unzip_file(os.path.join(os.path.dirname(car_export_path),
-                                      os.path.basename(car_export_path) + ".zip"))
-    return os.path.join(car_export_path, os.sep.join(["vehicles", beamng_mod_folder_name]))
+    found_path = None
+    for mod_location in installation.get_beamng_export_paths():
+        potential_path = os.path.join(mod_location, beamng_mod_folder_name)
+        if os.path.isdir(potential_path):
+            found_path = potential_path
+            break
+        zip_filename = os.path.join(os.path.dirname(potential_path), os.path.basename(potential_path) + ".zip")
+        if os.path.exists(zip_filename):
+            utils.unzip_file(zip_filename)
+            found_path = potential_path
+            break
+
+    if not found_path:
+        raise ValueError(f"Can't find {beamng_mod_folder_name} in {','.join(installation.get_beamng_export_paths())}")
+    return os.path.join(found_path, os.sep.join(["vehicles", beamng_mod_folder_name]))
 
 
 def load_car_file_data(directory):

--- a/sim_racing_tools/automation/installation.py
+++ b/sim_racing_tools/automation/installation.py
@@ -37,7 +37,8 @@ else:
     pass
 
 USER_GAME_DATA_PATH = os.sep.join(["My Games", GAME_NAME])
-BEAMNG_EXPORT_PATH = os.sep.join(["BeamNG.drive", "mods"])
+BEAMNG_MOD_PATH = os.sep.join(["BeamNG.drive", "mods"])
+BEAMNG_LATEST_VERSION_SHORTCUT = os.sep.join(["BeamNG.drive", "latest.lnk"])
 SANDBOX_DB_NAME = "Sandbox_openbeta.db"
 
 ENGINE_JBEAM_NAME = "camso_engine.jbeam"
@@ -55,6 +56,10 @@ def get_user_documents_dir():
         return shell.SHGetFolderPath(0, shellcon.CSIDL_PERSONAL, None, 0)
 
 
+def get_user_appdata_local():
+    return shell.SHGetFolderPath(0, shellcon.CSIDL_LOCAL_APPDATA, 0, 0)
+
+
 def get_userdata_path():
     return os.path.join(get_user_documents_dir(), USER_GAME_DATA_PATH)
 
@@ -63,8 +68,13 @@ def get_sandbox_db_path():
     return os.path.join(get_userdata_path(), SANDBOX_DB_NAME)
 
 
-def get_beamng_export_path():
-    return os.path.join(get_user_documents_dir(), BEAMNG_EXPORT_PATH)
+def get_beamng_export_paths():
+    locations = [os.path.join(get_user_documents_dir(), BEAMNG_MOD_PATH)]
+    latest_shortcut_path = os.path.join(get_user_appdata_local(), BEAMNG_LATEST_VERSION_SHORTCUT)
+    if os.path.exists(latest_shortcut_path):
+        import sim_racing_tools.utils as utils
+        locations.insert(0, os.path.join(utils.read_win_shortcut(latest_shortcut_path), 'mods'))
+    return locations
 
 
 class Installation(object):


### PR DESCRIPTION
In the latest versions of Automation and BeamNG the default folder where mods are exported to has changed to C:\Users\zephy\AppData\Local\BeamNG.drive\latest - latest is a shortcut to 0.22 at the time of writing.

Update the folders that are searched when trying to transfer an engine from a BeamNG export to include the new directory so the mods don't need to be copied anywhere